### PR TITLE
Fix slug generation when single translation exists

### DIFF
--- a/lib/friendly_id/history.rb
+++ b/lib/friendly_id/history.rb
@@ -118,12 +118,8 @@ method.
     end
 
     def create_slug
-      if self.translations.size > 1
-        self.translations.map(&:locale).each do |locale|
-          ::Globalize.with_locale(locale) { super_create_slug(locale) }
-        end
-      else
-        ::Globalize.with_locale(::Globalize.locale) { super_create_slug(locale) }
+      translations.map(&:locale).each do |locale|
+        ::Globalize.with_locale(locale) { super_create_slug(locale) }
       end
     end
 


### PR DESCRIPTION
In single translation case it was trying to call `locale` method on slugged model, not on translation.